### PR TITLE
Add dsh-remote to new 'Remote Access & Mobile' category

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ DeepSeek Harness is a runnable coding agent (Web UI + headless) built on [Cordis
   - [Notifications & Integrations](#notifications--integrations)
   - [Git & Engineering](#git--engineering)
   - [Security & Governance](#security--governance)
+  - [Remote Access & Mobile](#remote-access--mobile)
   - [Output & Deliverables](#output--deliverables)
   - [Domain & Specialist](#domain--specialist)
   - [Development & Runtime](#development--runtime)
@@ -231,6 +232,10 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [dfycaly98931680/dsh-trajectory-governance](https://github.com/dfycaly98931680/dsh-trajectory-governance) — Rebuilds session logs into multi-branch trajectory trees, detects loop deadlock, invalid retry, and goal drift, with cost-attributed alerts.
 - [DamonKoy/dsh-plugins (dsh-approve-for-me)](https://github.com/DamonKoy/dsh-plugins/tree/main/packages/dsh-approve-for-me) — Auto-approves read-only tools and auto-denies dangerous commands via a fail-closed policy engine.
 - [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) — Configurable per-turn budgets limiting distinct files, mutation calls, and payload bytes before file-mutation tools run.
+
+### Remote Access & Mobile
+
+- [mrgaoang/dsh-remote](https://github.com/mrgaoang/dsh-remote) — Password-gated reverse-proxy gateway to control the DSH Web UI from a phone browser with full feature coverage (including privileged methods): loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.
 
 ### Output & Deliverables
 


### PR DESCRIPTION
## What

Adds **dsh-remote** to a new **Remote Access & Mobile** category in the awesome list.

## About dsh-remote

[dsh-remote](https://github.com/mrgaoang/dsh-remote) — Password-gated reverse-proxy gateway to control the DSH Web UI from a phone browser with **full feature coverage (including privileged methods)**: loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.

## Why a new category

The existing list has LAN-access and auth-tunnel entries under *UI Enhancements* / *Security & Governance*, but no category for **mobile / remote-control gateways**. dsh-remote targets exactly that niche (phone-first remote control), so a dedicated category keeps it discoverable.

## Checklist

- [x] Entry is one line
- [x] Links the actual repo (not a fork/mirror)
- [x] Project installs and works as described