### PR TITLE
docs: add lcsdg/dsh-quick-prompts to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [hanzhangzzz/dsh-diagram](https://github.com/hanzhangzzz/dsh-diagram) — Editable Excalidraw diagrams embedded directly in conversations.
 - [giiiiiithub/terminal](https://github.com/giiiiiithub/terminal) — A real PTY terminal panel via node-pty and xterm.js, with multi-tab sessions and a dock/floating window.
 - [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) — Fluid streaming rendering and smooth scrolling for the DeepSeek Harness Web UI.
+- [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) — Quick-prompts bar above the DSH composer: per-category snippet chips, orange placeholder highlighting, two-column prompt/category management, and per-session category memory.
 - [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) — Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings flagged as you type. Uses the model dsh is already configured with, so no API key.
 - [Pasumao/dsh-plugin-choice-refresh](https://github.com/Pasumao/dsh-plugin-choice-refresh) — Adds "regenerate options" and "more options" buttons to ask_user_question / ask_user_choice cards — pure front-end, no core changes.
 - [Pasumao/dsh-plugin-image-tools](https://github.com/Pasumao/dsh-plugin-image-tools) — Image choice cards for ask_user_choice (zoomable), inline images in replies via show_images, and blind-model image capture — zero-token local rendering.


### PR DESCRIPTION
Add [lcsdg/dsh-quick-prompts](https://github.com/lcsdg/dsh-quick-prompts) to the **UI Enhancements** category.

A quick-prompts bar above the DeepSeek Harness composer: per-category snippet chips, orange placeholder highlighting, two-column prompt/category management, and per-session category memory.

Install: `dsh plugin --profile web add @max1997/dsh-quick-prompts`

Also published on npm and tagged with the `dsh-plugin` topic.