### PR TITLE
Add dsh-forge and dsh-sonarqube

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AngelosZou/graphlint](https://github.com/AngelosZou/graphlint/tree/main/integrations/dsh) — Dead-code detection for AI-generated codebases via dependency-graph reachability.
 - [loadingvx/deepseek-harness-workbench-plugin](https://github.com/loadingvx/deepseek-harness-workbench-plugin) — Full IDE workbench inside the Web UI: multi-tab editing, workspace terminal, file tree, and SCM (stage/commit/push/pull, branch switch, git graph, inline diffs).
 - [temotee2103/dsh-ci-co-pilot](https://github.com/temotee2103/dsh-ci-co-pilot) — GitHub CI co-pilot for DeepSeek Harness: PR review, CI failure fixing, issue triage and release notes.
+- [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) — Read-only Gitea and Forgejo tools for self-hosted instances: repositories, issue and pull request search, PR diffs and changed files, and Actions runs, jobs and job logs.
 
 ### Security & Governance
 
@@ -308,6 +309,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [liuqingman/dsh-hawkeye-scan](https://github.com/liuqingman/dsh-hawkeye-scan) — AI-driven source-code security scanning workbench: 5 model tools (start/finding/status/report/list) plus a /hawkeye web UI and JSON/Markdown/HTML vulnerability reports; zero-dependency Cordis plugin, installable as agent preset or npm package.
 - [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) — Named credential manager: the model uses API keys, tokens, and logins by reference; secrets are injected into each shell run as `DSH_CM_*` env vars and never enter the conversation.
 - [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) — LLM auto-review for sandbox-escalation approvals under the `'auto'` policy: deterministic filter plus a clean-context reviewer model, fail-closed on every error path; requires a patched harness core (patches in core-patches/).
+- [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) — Read-only SonarQube Community Build tools: Quality Gate for a branch or pull request, issue and Security Hotspot search, and coverage, duplication or caller-selected measures.
 
 ### Remote Access & Mobile
 


### PR DESCRIPTION
Two read-only plugins, one line each under the matching category.

**[maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge)** → Git & Engineering
Gitea / Forgejo tools over the REST API both projects share — eleven read-only tools covering repositories, issue and PR search, PR diffs and changed files, and Actions runs, jobs and logs. Published as `@maxhsu/dsh-forge`.

**[maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube)** → Security & Governance
SonarQube Community Build tools — six read-only tools covering instance status, Quality Gate (branch or PR), issue and Security Hotspot search, hotspot detail, and coverage / duplication / caller-selected measures. Published as `dsh-sonarqube`.

Both are MIT, carry the `dsh-plugin` topic, declare `dsh.bundle` in `package.json`, and are on npm so installs are prebuilt. Insertions only — no existing entry touched.