### PR TITLE
Add dsh-grafana-query, dsh-sentry and dsh-odoo (Tools & Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) — Security-audit skill pack plus the plugin_vet supply-chain gate: eight bilingual agent skills and an automated pre-install scanner.
 - [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) — Transactional uninstall engine: every destructive action runs validate/preview/execute/undo with Saga rollback, WAL crash recovery, hash-chain audit, hardlink dedup, and a Bayesian oracle that predicts success probability before you commit.
 - [xiehuan123/dsh-deepread](https://github.com/xiehuan123/dsh-deepread) — Evidence-first deep reading for books, articles, PDFs, and document sets with claim-evidence reports, knowledge maps, recall questions, a Host tool, and an optional Web reading panel.
+- [maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query) — Read-only Grafana tools over the data source proxy: instance health, data sources, instant and range PromQL queries, current alert state, and provisioned alert rules.
+- [maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry) — Read-only Sentry tools: project listing, issue search and detail, and the latest or a specific event with a trimmed stacktrace that drops local variables, request data, and secret-looking tags.
+- [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) — Read-only Odoo tools over JSON-RPC: server info, model field introspection, and a restricted search_read on an allow list of models; a draft-create tool is registered only when allowWrite is enabled.
 
 ### Vision & Multimodal
 


### PR DESCRIPTION
Three read-only service integrations, one line each under **Tools & Capabilities** — they add external-service tools to the agent rather than DSH-internal telemetry or governance, so they sit with the other tool-adding plugins.

**[maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query)** — npm `dsh-grafana-query`
Read-only Grafana tools over the data source proxy: instance health, data sources, instant and range PromQL queries, current alert state, and provisioned alert rules.

**[maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry)** — npm `dsh-sentry`
Read-only Sentry tools: project listing, issue search and detail, and the latest or a specific event with a trimmed stacktrace that drops local variables, request data, and secret-looking tags.

**[maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo)** — npm `dsh-odoo`
Read-only Odoo tools over JSON-RPC: server info, model field introspection, and a restricted search_read on an allow list of models. The single draft-create tool is registered only when `allowWrite` is turned on, so the default install is read-only.

All three are MIT, have zero runtime dependencies, declare `dsh.bundle` (with a committed `cordis.patch.yml` patch) in `package.json`, carry the `dsh-plugin` topic, and are published to npm so installs are prebuilt.

Checked locally before submitting: `git diff --name-only upstream/main..HEAD` is `README.md` only, the diff is 3 insertions and 0 deletions (no existing entry touched), the branch is cut from `upstream/main` so it is up to date with #92, and the file's leading BOM is preserved. Each link resolves to the real plugin repo, not a fork or mirror.