### PR TITLE
Add dsh-lit-search and dsh-latex-guard plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
 - [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders.
 - [liyc-sys/dsh-fixed-income-skills](https://github.com/liyc-sys/dsh-fixed-income-skills) — Fixed-income / credit skills: issuer rating-migration watch (fundamentals + market-implied spread + catalysts) and rate-scenario analysis (historically anchored curve scenarios with duration-based exposure impact). Ported from the LLMQuant financial Agent Skills library.
+- [Flan246/dsh-lit-search](https://github.com/Flan246/dsh-lit-search) — Academic literature search, citation formatting (GB/T 7714 / APA / BibTeX) and related-works tools, powered by Crossref + OpenAlex with no API key. Install via `dsh plugin add dsh-lit-search`.
+- [Flan246/dsh-latex-guard](https://github.com/Flan246/dsh-latex-guard) — LaTeX compile check (auto xelatex/lualatex detection) plus BibTeX lint, field-fill and cite-audit tools. Install via `dsh plugin add dsh-latex-guard`.
 
 ### Development & Runtime
 


### PR DESCRIPTION
Adds two DSH plugins:
- **dsh-lit-search** — academic literature search, citation formatting (GB/T 7714 / APA / BibTeX) and related-works tools (Crossref + OpenAlex, no API key). Install: `dsh plugin add dsh-lit-search`.
- **dsh-latex-guard** — LaTeX compile check (auto xelatex/lualatex detection) plus BibTeX lint/fill/cite-audit tools. Install: `dsh plugin add dsh-latex-guard`.

Both work with DeepSeek Harness and any agent.