### PR TITLE
Add Leo3-7/dsh-obsidian-inbox (Obsidian ingest skill, dsh.bundle skill-pack) to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Awesome DSH Plugin [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# Awesome DSH Plugin [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated guide to [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) — DeepSeek's open-source, everything-is-a-plugin coding agent — and the best community plugins built on it.
 
@@ -227,6 +227,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 ### Skills
 
 - [AKS1st/dsh-skill-manager](https://github.com/AKS1st/dsh-skill-manager) — Browse and edit system/user/workspace/preset skills, import from zip, export or delete.
+- [Leo3-7/dsh-obsidian-inbox](https://github.com/Leo3-7/dsh-obsidian-inbox) — Obsidian 知识库入库技能：按 7 步标准流程把 DSH 对话的结论/错题/项目整理进 Obsidian，含公式与结构两级确定性校验脚本 (Obsidian knowledge-base ingest skill, installed as a `dsh.bundle` skill-pack with two-level validation).
 - [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) — Software-engineering method pack: baseline-first planning, systematic debugging, and verification before completion.
 - [gongyijie85/dsh-ecc](https://github.com/gongyijie85/dsh-ecc) — 273 ECC skills ported from a large operator-system skill catalog.
 - [hackerFish/awesome-dsh-skills](https://github.com/hackerFish/awesome-dsh-skills) — 12 tested engineering skills, each passing a format validator and an isolated load smoke test.


### PR DESCRIPTION
﻿Adds [Leo3-7/dsh-obsidian-inbox](https://github.com/Leo3-7/dsh-obsidian-inbox) to the **Skills** section.

Obsidian 知识库入库技能 / Obsidian knowledge-base ingest skill — a `dsh.bundle` skill-pack that follows the "everything is a plugin" principle:

- **Bundled skill** — registers `skills/obsidian-inbox/SKILL.md` on `ctx.skills` as a `bundled` provider (7-step ingest workflow: authorize → retrieve → distill → classify → merge → validate → report).
- **Model tool** — exposes two-level vault validation as `obsidian_validate_vault` (formula `$`/`$$` syntax, `.obsidian` JSON, `[[Wiki Link]]` targets, duplicate-note ambiguity) instead of a bare shell script.
- **Declarative config** — vault path resolved from a schemastery `Config.defaultVault` (no hardcoded paths), plus a `systemPrompt` section guiding the model to the tool.

Install:
```sh
dsh plugin --profile <name> add https://github.com/Leo3-7/dsh-obsidian-inbox
```
