### PR TITLE
Add dsh-whale-musume: whale-girl desktop pet (Just for Fun)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — Turns coding into an RPG: XP, 27+ achievement badges, levels, and seasons.
 - [minybear/DeepSeek-Harness-Pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex-style desktop pet mirroring the agent's running state.
 - [Nagi-ovo/dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — Parody ads in 2005-Chinese-web style. All fictional.
+- [Sutera-Diffusus/dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - Whale-girl desktop pet for the DSH Web UI: pat-to-raise growth, live work-state poses, 494 dialogue lines, 30 achievements and a built-in settings panel - all local, zero telemetry.
 - [ywleeo/dsh-md-preview](https://github.com/ywleeo/dsh-md-preview) — Sidebar workspace-row trigger opens a Markdown preview panel: nested collapsible directory tree, inline rendering, theme-aware, open in the system default app.
 
 ## Writing Your Own Plugin


### PR DESCRIPTION
Add [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) to **Just for Fun**.

Whale-girl desktop pet for the DSH Web UI: pat-to-raise growth, live work-state poses (per tool type), 494 dialogue lines, 30 achievements, drag physics with inertia, theme sync, built-in settings panel. Local-first, zero telemetry, MIT, 102 unit tests, tested on DSH 0.1.1-rc.2. Submit from the maintainer of the plugin.

- Repo: https://github.com/Sutera-Diffusus/dsh-whale-musume
- Install: `dsh plugin --profile web add github:Sutera-Diffusus/dsh-whale-musume`
- Already listed in [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) (data/plugins) and tagged with the `dsh-plugin` topic.