### PR TITLE
Add nickkkkkk123123/dsh-whale-girl

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — Turns coding into an RPG: XP, 27+ achievement badges, levels, and seasons.
 - [minybear/DeepSeek-Harness-Pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex-style desktop pet mirroring the agent's running state.
 - [Nagi-ovo/dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — Parody ads in 2005-Chinese-web style. All fictional.
+- [nickkkkkk123123/dsh-whale-girl](https://github.com/nickkkkkk123123/dsh-whale-girl) — Interactive whale-girl desktop pet for DeepSeek Harness: live balance/usage/context occupancy, middle-button slingshot toss, easter-egg bubbles, eco mode. 346KB package, zero extra processes.
 - [ywleeo/dsh-md-preview](https://github.com/ywleeo/dsh-md-preview) — Sidebar workspace-row trigger opens a Markdown preview panel: nested collapsible directory tree, inline rendering, theme-aware, open in the system default app.
 
 ## Writing Your Own Plugin


### PR DESCRIPTION
Adds the whale-girl desktop pet plugin (ui/desktop-pet). Live balance/usage/context occupancy, slingshot toss, eco mode. Install: dsh plugin add nickkkkkk123123/dsh-whale-girl. Repo: https://github.com/nickkkkkk123123/dsh-whale-girl