### PR TITLE
Add dsh-plugin-hub to Plugin Markets & Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Awesome DSH Plugin [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# Awesome DSH Plugin [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated guide to [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) — DeepSeek's open-source, everything-is-a-plugin coding agent — and the best community plugins built on it.
 
@@ -369,6 +369,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) — npm-authoritative catalog plus curated list (550+ plugins), with quality verification.
 - [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) — Scouts every `dsh-plugin`-tagged repo and judges each as worth trying, watching, or skipping.
 - [chenzhi-clude/dsh-plugin-market](https://github.com/chenzhi-clude/dsh-plugin-market) — AI-native marketplace with a machine-readable registry (all.json + llms.txt) built for agent-driven plugin search and one-command install.
+- [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH plugin management panel and marketplace: one-click enable/disable, multi-source search (GitHub/Gitee/custom), static plugin & skill index, suite/skill install, source management, and one-click framework upgrade with auto-rollback.
 
 ### Just for Fun
 


### PR DESCRIPTION
## 收录申请

添加 [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) 到 **Plugin Markets & Managers** 分类。

- DSH 插件管理面板 + 市场
- 一键启停插件
- 多源市场：GitHub / Gitee / 自定义
- 静态插件/技能索引
- 技能/套装安装
- 框架一键升级（自动备份/回滚/重启）
- npm: @noob-stupid/dsh-plugin-console