### PR TITLE
docs: add dsh-product-subagent-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [EvilIrving/dsh-proof](https://github.com/EvilIrving/dsh-proof) — Independent read-only acceptance layer verifying each turn before it closes.
 - [fakechris/dsh-track](https://github.com/fakechris/dsh-track) — Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store.
 - [february2015/dsh-taskswarm](https://github.com/february2015/dsh-taskswarm) — Dependency-ordered task waves run in parallel git-worktree lanes with cross-model review and crash recovery.
+- [Jokasa7/dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) — Conversation-native multi-Agent planning and observability: editable task graphs, real child-session trees, plan-versus-run comparison, scoped recovery previews, and reusable run evidence.
 - [dickpy/dsh-cloud-sync](https://github.com/dickpy/dsh-cloud-sync) — Syncs DSH profiles and plugin archives through WebDAV/S3-compatible storage with encrypted snapshots.
 - [PerryLink/dsh-github](https://github.com/PerryLink/dsh-github) — Official-grade GitHub CI integration: a composite action, polling PR review bot with idempotent inline comments, a status-check gate, and approval-gated PR/issue tools.
 - [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) — LSP action surface: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints and rename over real language servers.


### PR DESCRIPTION
## Summary

Add `Jokasa7/dsh-product-subagent-console` to **Workflow & Automation** with one factual entry.

It is a DSH v0.9.0 plugin for conversation-native multi-Agent task planning and observability: editable task graphs, real child-session trees, plan-versus-run comparison, scoped recovery previews, and reusable run evidence.

- Source: https://github.com/Jokasa7/dsh-product-subagent-console
- DSH compatibility: 0.1.1-rc.2
- Install path: checksummed, provenance-attested Release `.tgz`, documented in the project README