### PR TITLE
Add sofagent to Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 
 ### Security & Governance
 
+- [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) — Commit-time agent governance harness: 24 deterministic audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt-injection traces), HMAC-chained tamper-evident history, 9-plugin DSH family via SkillHub.
 - [cdxiaodong/dsh-guardian](https://github.com/cdxiaodong/dsh-guardian) — Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations.
 - [JohnXu22786/secret-guard](https://github.com/JohnXu22786/secret-guard) — Blocks agents from reading or writing sensitive files (.env, credentials, keys), masks leaked secret-shaped values, and keeps an audit journal.
 - [LeslieWylie/dsh-fleet-audit](https://github.com/LeslieWylie/dsh-fleet-audit) — Read-only agent-fleet credential-hygiene audit: file permissions, embedded credentials in git remotes, provider-token literal counts.


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **Security & Governance** section.

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is a commit-time governance harness for AI coding agents: 24 deterministic audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt-injection traces), HMAC-chained tamper-evident audit history, and a 9-plugin DSH family (audit / gate / rollback / inject / ontology / evolve / commons / daemon / fde) under `engine/dsh-plugins/cordis-plugin-sofagent-*`, installable via SkillHub (`skillhub install cordis-plugin-sofagent-*`).

Also available as a GitHub Action ([marketplace](https://github.com/marketplace/actions/sofagent)) and MCP server.

Related listings: [punkpeye/awesome-mcp-servers #13312](https://github.com/punkpeye/awesome-mcp-servers/pull/13312), [Glama](https://glama.ai/mcp/servers/KongFangXun/sofagent), [agentrust-io/awesome-ai-governance #89](https://github.com/agentrust-io/awesome-ai-governance/pull/89), [0xsline/awesome-deepseek-harness #547](https://github.com/0xsline/awesome-deepseek-harness/pull/547).