### PR TITLE
Add free-best-router to Models & Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [fieldnote-ops/keyringseam](https://github.com/fieldnote-ops/keyringseam) — macOS Keychain credential provider replacing the local-file default.
 - [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) — Connects ChatGPT OAuth / OpenAI Codex models to the harness.
 - [GodD6366/dsh-sub2api](https://github.com/GodD6366/dsh-sub2api) — OpenAI-compatible multi-provider routes (OpenAI/Claude/Grok/Gemini) behind one base URL.
+- [MajidAsghariTabrizi/free-best-router](https://github.com/MajidAsghariTabrizi/free-best-router) — OpenAI-compat routing layer across 7 free LLM providers (OpenRouter, OpenCode/Zen, Groq, Cerebras, Mistral, DeepSeek, local) with Wilson + Bayesian scoring, per-failure cooldowns, and bounded 4-attempt fallback. MIT, zero telemetry.
 - [kam74515-boop/dsh-everything-oauth](https://github.com/kam74515-boop/dsh-everything-oauth) — Imports existing Codex, Grok, Claude, and OpenCode logins so you don't re-auth per tool.
 - [katsos/dsh-claude-cli](https://github.com/katsos/dsh-claude-cli) — Runs the local Claude Code CLI as a model backend over an existing subscription instead of a metered key.
 - [NOirBRight/dsh-llm-ollama](https://github.com/NOirBRight/dsh-llm-ollama) — Ollama Cloud native chat adapter with model discovery and web search/fetch providers.


### PR DESCRIPTION
Adds [free-best-router](https://github.com/MajidAsghariTabrizi/free-best-router) to the **Models & Providers** section.

It is an OpenAI-compat routing layer across 7 free LLM providers (OpenRouter, OpenCode/Zen, Groq, Cerebras, Mistral, DeepSeek, and local Ollama / LM Studio / llama.cpp) with:

- Capability-aware ranking (7 weighted components: capability fit, agentic quality, reliability, coding quality, context fit, tool quality, latency)
- Wilson lower bound on success rate plus time-decay penalties
- Per-failure-type cooldowns (60s base for 429, 30-min base for 404 with 1h cap, exponential backoff)
- Bounded failover: up to 4 model attempts, 45s per attempt, with `Retry-After` and `next_eligible_model` headers when the pool is exhausted
- 5% smart exploration restricted to healthy, capability-close runners-up

DSH integration is a 6-line YAML config block (no native plugin needed). Full write-up in the [DSH "Show Your Plugins!" discussion #5508](https://github.com/deepseek-ai/deepseek-harness/discussions/5508).

Entry matches the existing one-line format used in this section.

**Disclosure:** this is my own open-source project. I rewrote the entry to use capability-based wording only (no hard-coded metric counts), per the maintainer's earlier feedback on similar entries.
