### PR TITLE
add universal-engineering-agent: 9-stage operating kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 
 ### Development & Runtime
 
+- [MajidAsghariTabrizi/universal-engineering-agent](https://github.com/MajidAsghariTabrizi/universal-engineering-agent) — Profile-agnostic, runnable, MIT reference implementation of the UEA 9-stage operating-kernel contract. Inspect → plan → implement → verify → classify → recover → test → generalize. Zero runtime deps. ([DSH #5513](https://github.com/deepseek-ai/deepseek-harness/discussions/5513))
 - [863683348/dsh-plugin-verify](https://github.com/863683348/dsh-plugin-verify) — Evidence-based claim checking against workspace files with line citations.
 - [863683348/dsh-trend-radar](https://github.com/863683348/dsh-trend-radar) — Ecosystem trend dashboard: new plugins, star gainers, category heat, keyword radar.
 - [ai-eks/dsh-auth-tunnel](https://github.com/ai-eks/dsh-auth-tunnel) — Password-gated public access through Cloudflare Tunnels with an in-app directory picker.


### PR DESCRIPTION
Adds [universal-engineering-agent](https://github.com/MajidAsghariTabrizi/universal-engineering-agent) — a profile-agnostic, runnable, MIT reference implementation of the UEA operating-kernel contract.

Capabilities:

- 9-stage kernel: inspect, plan, implement, verify, classify, recover, test, generalize (plus a tool-hygiene tracker)
- 10-class failure classifier with bounded retry and non-retryable fall-through
- Stage-4 staged runner (STATIC → UNIT → INTEGRATION) for the user's code
- Stage-7 self-tests for the agent's own code (uses `node --test`, plain Node, no test framework dependency)
- Profile-agnostic: product-specific knowledge lives in a profile, not in the kernel
- Zero runtime dependencies; runs on Node 18.17+
- Sibling to free-best-router (this one coordinates an engineering agent; free-best-router picks the model)

DSH integration: the kernel contract is the public-spec counterpart of the production `dsh-universal-harness-core` plugin. Full write-up at https://github.com/deepseek-ai/deepseek-harness/discussions/5513.

**Disclosure:** this is my own open-source project. I rewrote the entry to use capability-based wording only (no hard-coded metric counts), per the maintainer's earlier feedback on similar entries.
