### PR TITLE
docs: add Ox0400/dsh-vault (security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) — Named credential manager: the model uses API keys, tokens, and logins by reference; secrets are injected into each shell run as `DSH_CM_*` env vars and never enter the conversation.
 - [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) — LLM auto-review for sandbox-escalation approvals under the `'auto'` policy: deterministic filter plus a clean-context reviewer model, fail-closed on every error path; requires a patched harness core (patches in core-patches/).
 
+- [Ox0400/dsh-vault](https://github.com/Ox0400/dsh-vault) — Encrypted local credentials vault for dsh: a web settings page and vault_* tools for passwords, API keys, TOTP secrets and cards, with health audits, expiry rotation, imports/exports and read-only/ask access modes.
+
 ### Remote Access & Mobile
 
 - [Phant0Meow/dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth) — Mobile-first UX polish for the DSH Web UI (composer auto-fold, compact mobile sidebar/header/settings, zoom lock) plus notifications when AI finishes long tasks or asks for permission (in-page cards, Web Push, Bark webhook); zero dsh changes, Tailscale phone-access guide included.


### PR DESCRIPTION
Add [Ox0400/dsh-vault](https://github.com/Ox0400/dsh-vault) under Security & Governance — an encrypted **local** credentials vault (passwords / API keys / TOTP secrets / cards) with a web settings page and vault_* tools; health audits, expiry rotation, imports/exports, read-only/ask modes. Repo declares `dsh.bundle` + `cordis.patch.yml`, published on npm, `dsh-plugin` topic set; concurrently submitted to awesome-dsh-plugin (PR #4257).