### PR TITLE
docs: add xgone/dsh-netshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Phant0Meow/dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth) — Mobile-first UX polish for the DSH Web UI (composer auto-fold, compact mobile sidebar/header/settings, zoom lock) plus notifications when AI finishes long tasks or asks for permission (in-page cards, Web Push, Bark webhook); zero dsh changes, Tailscale phone-access guide included.
 - [mrgaoang/dsh-remote](https://github.com/mrgaoang/dsh-remote) — Password-gated reverse-proxy gateway to control the DSH Web UI from a phone browser with full feature coverage (including privileged methods): loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.
 - [Dawn388887/dsh-fileview](https://github.com/Dawn388887/dsh-fileview) — In-GUI file viewer/editor for remote browsers: same-origin fenced, path-allowlisted, encoding-preserving saves.
+- [xgone/dsh-netshell](https://github.com/xgone/dsh-netshell) — Local and remote SSH terminals for DeepSeek Harness Web, with three permission levels, human approval for risky AI commands, and encrypted credential storage.
 
 ### Output & Deliverables
 


### PR DESCRIPTION
## Summary

Add `xgone/dsh-netshell` to Remote Access & Mobile.

The plugin provides local and remote SSH terminals for DeepSeek Harness Web, three permission levels, human approval for risky AI commands, and encrypted credential storage.

The repository is public, has the `dsh-plugin` topic, declares a `dsh.bundle` manifest, and is published as `@xgone/dsh-netshell@0.6.0`. This PR contains only one new README entry.
