### PR TITLE
docs: add xgone/dsh-remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 
 - [Phant0Meow/dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth) — Mobile-first UX polish for the DSH Web UI (composer auto-fold, compact mobile sidebar/header/settings, zoom lock) plus notifications when AI finishes long tasks or asks for permission (in-page cards, Web Push, Bark webhook); zero dsh changes, Tailscale phone-access guide included.
 - [mrgaoang/dsh-remote](https://github.com/mrgaoang/dsh-remote) — Password-gated reverse-proxy gateway to control the DSH Web UI from a phone browser with full feature coverage (including privileged methods): loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.
+- [xgone/dsh-remote](https://github.com/xgone/dsh-remote) — Secure remote access for the DSH Web UI: account/password login gate, MFA/TOTP, role-based access, and an allowlisted in-browser file preview panel.
 - [Dawn388887/dsh-fileview](https://github.com/Dawn388887/dsh-fileview) — In-GUI file viewer/editor for remote browsers: same-origin fenced, path-allowlisted, encoding-preserving saves.
 
 ### Output & Deliverables


### PR DESCRIPTION
## Summary

Add `xgone/dsh-remote` to the Remote Access & Mobile section.

The plugin adds a login gate, MFA/TOTP, role-based access, and an allowlisted in-browser file preview panel to the DSH Web UI.
