### PR TITLE
Add weibaohui/dsh-continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) — Rolls conversation and workspace files back to before any user message, via shadow git snapshots with a diff-preview confirmation.
 - [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — Inline edit & recall for user-message bubbles in DSH Web — lazy commit, seamless replacement, version pager, draft auto-backup, trilingual i18n. DSH Web 内用户消息气泡内联编辑与撤回插件：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n。
 
+- [weibaohui/dsh-continue](https://github.com/weibaohui/dsh-continue) — Auto-resume for interrupted sessions: rules route by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume-after-compaction, or stop-loss notification, with a visual rule editor and activity log.
+
 ### Memory
 
 - [863683348/dsh-plugin-focus](https://github.com/863683348/dsh-plugin-focus) — Durable focus board pinning objective, constraints, and decisions across compaction and sessions.


### PR DESCRIPTION
Adds **weibaohui/dsh-continue** to **Sessions & Messages**.

Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into automatic backoff retry, model switch, resume after context compaction, or a stop-loss notification — with a visual rule editor and a full activity log.

- npm: [@weibaohui/dsh-continue](https://www.npmjs.com/package/@weibaohui/dsh-continue) (v0.3.0), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/dsh-continue`
- Repo: https://github.com/weibaohui/dsh-continue (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/dsh-continue/blob/main/docs/demo.gif
