### PR TITLE
Add weibaohui/hermes-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-score](https://github.com/PerryLink/dsh-score) — Multi-dimensional quality scoring for DSH plugins (install, maintenance, docs, security, protocol compliance) with real CLI evidence and a JSON/Markdown leaderboard.
 - [PerryLink/dsh-test-drive](https://github.com/PerryLink/dsh-test-drive) — Isolated install-and-smoke test drives for DSH plugins in throwaway DSH_HOME profiles, emitting structured pass/fail result matrices.
 - [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — A super-simplified LLM-wiki memory plugin: one index document (auto-loaded) + one markdown file per topic (read only when needed) — no dumping everything into the context and burning tokens. Simple and lightweight, painless to install/uninstall, and freely editable however you like.
+- [weibaohui/hermes-loop](https://github.com/weibaohui/hermes-loop) — Automatic post-conversation retrospective that distills useful experience into reusable skills for the skill library, with approval mode and skill-library governance (archive/restore, never deletes directly).
+
 ### Tools & Capabilities
 
 - [988hj7tczd-oss/dsh-computer-use](https://github.com/988hj7tczd-oss/dsh-computer-use) — Cross-platform Computer Use: virtual-mouse operation, AX-tree zero-vision-cost mode, and safety guards.


### PR DESCRIPTION
Adds **weibaohui/hermes-loop** to **Memory**.

Automatic post-conversation retrospective: after a conversation wraps up, it distills useful experience into reusable skills stored in the skill library for the model to call, with signal-accelerated triggers, manual runs, an approval mode, and skill-library governance (archive/restore, never deletes directly).

- npm: [@weibaohui/hermes-loop](https://www.npmjs.com/package/@weibaohui/hermes-loop) (v0.1.4), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/hermes-loop`
- Repo: https://github.com/weibaohui/hermes-loop (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/hermes-loop/blob/main/docs/demo.gif
