### PR TITLE
Add weibaohui/dsh-settings-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [stephenlzc/dsh-swarm-panel#dsh-swarm-plugin](https://github.com/stephenlzc/dsh-swarm-panel/tree/main/dsh-swarm-plugin) — Conversation Flow observability for DeepSeek Harness swarms, with topology, routed-message inspection, HITL pauses, Live follow, and child-session navigation.
 - - [ssjob123/dsh-file-panel-left](https://github.com/ssjob123/dsh-file-panel-left) — Files-only workbench sidebar: always-docked file tree, CodeMirror editor, previews, and @-references with real line numbers.
 
+- [weibaohui/dsh-settings-ui](https://github.com/weibaohui/dsh-settings-ui) — Customizes the native settings window: preset/custom sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access; saved in the local browser.
+
 ### Usage & Billing
 
 - [melvinWEN/dsh-elegent-balance-tracker](https://github.com/melvinWEN/dsh-elegent-balance-tracker) — Elegant billing tracker: per-session cost (official peak/off-peak pricing by message time) under the composer stats plus official account balance right-aligned on the sidebar settings row, with per-minute balance re-alignment and real-time local-cost deduction in between.


### PR DESCRIPTION
Adds **weibaohui/dsh-settings-ui** to **UI Enhancements**.

Customizes the native settings window of the DSH web UI: preset or custom window sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access. Light and dark themes store separate colors; saved in the local browser.

- npm: [@weibaohui/dsh-settings-ui](https://www.npmjs.com/package/@weibaohui/dsh-settings-ui) (v0.2.0), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/dsh-settings-ui`
- Repo: https://github.com/weibaohui/dsh-settings-ui (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/dsh-settings-ui/blob/main/docs/demo.gif
