### PR TITLE
Add SunshineR04/dsh-session-manager to Sessions & Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [fredalxin/dsh-solo-thinking](https://github.com/fredalxin/dsh-solo-thinking) — Visual branch brainstorming: isolated session per direction with automated parent/sibling/checkpoint handoffs and a full tree tab.
 - [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) — Rolls conversation and workspace files back to before any user message, via shadow git snapshots with a diff-preview confirmation.
 - [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — Inline edit & recall for user-message bubbles in DSH Web — lazy commit, seamless replacement, version pager, draft auto-backup, trilingual i18n. DSH Web 内用户消息气泡内联编辑与撤回插件：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n。
+- [SunshineR04/dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — Manage archived sessions from the Settings page: restore or permanently delete them; red delete item in the session context menu, /sessions slash commands and three agent tools; open sessions delete immediately (tombstone cleanup after restart).
 
 ### Memory
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [fredalxin/dsh-solo-thinking](https://github.com/fredalxin/dsh-solo-thinking) — Visual branch brainstorming: isolated session per direction with automated parent/sibling/checkpoint handoffs and a full tree tab.
 - [limbo947/dsh-recall-plugin](https://github.com/limbo947/dsh-recall-plugin) — Rolls conversation and workspace files back to before any user message, via shadow git snapshots with a diff-preview confirmation.
 - [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — Inline edit & recall for user-message bubbles in DSH Web — lazy commit, seamless replacement, version pager, draft auto-backup, trilingual i18n. DSH Web 内用户消息气泡内联编辑与撤回插件：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n。
-- [SunshineR04/dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — Manage archived sessions from the Settings page: restore or permanently delete them; red delete item in the session context menu, /sessions slash commands and three agent tools; open sessions delete immediately (tombstone cleanup after restart).
+- [SunshineR04/dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — Manage archived sessions from the Settings page: restore or permanently delete them; red delete item in the session context menu; open sessions delete immediately (tombstone cleanup after restart).
 
 ### Memory
 


### PR DESCRIPTION
Adds [SunshineR04/dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — a DeepSeek Harness plugin that manages archived sessions:

- Settings page (Settings → Session Manager): list archived sessions, restore, permanently delete
- Red **Delete permanently** item in the session context menu
- `/sessions` slash commands and three agent tools (`session_list_archived`, `session_restore_archived`, `session_delete_permanently`)
- Open sessions delete immediately: bookkeeping + files removed at once, the lingering in-memory summary stays hidden via an archive-set tombstone and is cleaned up at the next restart
- Declares a `dsh.bundle` manifest + `cordis.patch.yml`; MIT licensed; 20 unit/render tests