### PR TITLE
Add weibaohui/dsh-tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [dickpy/dsh-cloud-sync](https://github.com/dickpy/dsh-cloud-sync) — Syncs DSH profiles and plugin archives through WebDAV/S3-compatible storage with encrypted snapshots.
 - [PerryLink/dsh-github](https://github.com/PerryLink/dsh-github) — Official-grade GitHub CI integration: a composite action, polling PR review bot with idempotent inline comments, a status-check gate, and approval-gated PR/issue tools.
 - [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) — LSP action surface: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints and rename over real language servers.
+- [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) — Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.
 
 ### Notifications & Integrations
 


### PR DESCRIPTION
Adds **weibaohui/dsh-tasks** to **Workflow & Automation**.

Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.

- npm: [@weibaohui/dsh-tasks](https://www.npmjs.com/package/@weibaohui/dsh-tasks) (v0.4.2), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/dsh-tasks`
- Repo: https://github.com/weibaohui/dsh-tasks (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/dsh-tasks/blob/main/docs/demo.gif
