### PR TITLE
Add weibaohui/experts-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
 - [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders.
 - [liyc-sys/dsh-fixed-income-skills](https://github.com/liyc-sys/dsh-fixed-income-skills) — Fixed-income / credit skills: issuer rating-migration watch (fundamentals + market-implied spread + catalysts) and rate-scenario analysis (historically anchored curve scenarios with duration-based exposure impact). Ported from the LLMQuant financial Agent Skills library.
+- [weibaohui/experts-management](https://github.com/weibaohui/experts-management) — Expert manager: manage ntd-format experts and expert teams (plugin.json + Agent MD + skill sets), browse and install from a built-in market of 50+ experts, and run tasks in an expert persona via /expert-<name> without consuming model directory tokens.
 
 ### Development & Runtime
 


### PR DESCRIPTION
Adds **weibaohui/experts-management** to **Domain & Specialist**.

Expert manager: manage ntd-format experts and expert teams (plugin.json + Agent MD + skill sets), browse and install from a built-in market of 50+ experts, and run tasks in an expert persona via /expert-<name> without consuming model directory tokens.

- npm: [@weibaohui/experts-management](https://www.npmjs.com/package/@weibaohui/experts-management) (v0.4.3), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/experts-management`
- Repo: https://github.com/weibaohui/experts-management (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/experts-management/blob/main/docs/demo.gif
