### PR TITLE
Add weibaohui/user-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [liuqingman/dsh-hawkeye-scan](https://github.com/liuqingman/dsh-hawkeye-scan) — AI-driven source-code security scanning workbench: 5 model tools (start/finding/status/report/list) plus a /hawkeye web UI and JSON/Markdown/HTML vulnerability reports; zero-dependency Cordis plugin, installable as agent preset or npm package.
 - [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) — Named credential manager: the model uses API keys, tokens, and logins by reference; secrets are injected into each shell run as `DSH_CM_*` env vars and never enter the conversation.
 - [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) — LLM auto-review for sandbox-escalation approvals under the `'auto'` policy: deterministic filter plus a clean-context reviewer model, fail-closed on every error path; requires a patched harness core (patches in core-patches/).
+- [weibaohui/user-management](https://github.com/weibaohui/user-management) — Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs.
 
 ### Remote Access & Mobile
 


### PR DESCRIPTION
Adds **weibaohui/user-management** to **Security & Governance**.

Login gate for the dsh web UI: unauthenticated visitors get a login/register page and the first registrant becomes admin; includes user and role management plus login and access audit logs.

- npm: [@weibaohui/user-management](https://www.npmjs.com/package/@weibaohui/user-management) (v0.6.1), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/user-management`
- Repo: https://github.com/weibaohui/user-management (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/user-management/blob/main/docs/demo.gif
