### PR TITLE
Add weibaohui/context-razor

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-score](https://github.com/PerryLink/dsh-score) — Multi-dimensional quality scoring for DSH plugins (install, maintenance, docs, security, protocol compliance) with real CLI evidence and a JSON/Markdown leaderboard.
 - [PerryLink/dsh-test-drive](https://github.com/PerryLink/dsh-test-drive) — Isolated install-and-smoke test drives for DSH plugins in throwaway DSH_HOME profiles, emitting structured pass/fail result matrices.
 - [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — A super-simplified LLM-wiki memory plugin: one index document (auto-loaded) + one markdown file per topic (read only when needed) — no dumping everything into the context and burning tokens. Simple and lightweight, painless to install/uninstall, and freely editable however you like.
+- [weibaohui/context-razor](https://github.com/weibaohui/context-razor) — Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization.
 ### Tools & Capabilities
 
 - [988hj7tczd-oss/dsh-computer-use](https://github.com/988hj7tczd-oss/dsh-computer-use) — Cross-platform Computer Use: virtual-mouse operation, AX-tree zero-vision-cost mode, and safety guards.


### PR DESCRIPTION
Adds **weibaohui/context-razor** to **Memory**.

Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization.

- npm: [@weibaohui/context-razor](https://www.npmjs.com/package/@weibaohui/context-razor) (v0.4.2), `package.json` declares `dsh.bundle`
- Install: `dsh plugin --profile web add @weibaohui/context-razor`
- Repo: https://github.com/weibaohui/context-razor (has the `dsh-plugin` topic)
- Demo: https://github.com/weibaohui/context-razor/blob/main/docs/demo.gif
