### PR TITLE
Add dearbld/dsh-living-memory to Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-score](https://github.com/PerryLink/dsh-score) — Multi-dimensional quality scoring for DSH plugins (install, maintenance, docs, security, protocol compliance) with real CLI evidence and a JSON/Markdown leaderboard.
 - [PerryLink/dsh-test-drive](https://github.com/PerryLink/dsh-test-drive) — Isolated install-and-smoke test drives for DSH plugins in throwaway DSH_HOME profiles, emitting structured pass/fail result matrices.
 - [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — A super-simplified LLM-wiki memory plugin: one index document (auto-loaded) + one markdown file per topic (read only when needed) — no dumping everything into the context and burning tokens. Simple and lightweight, painless to install/uninstall, and freely editable however you like.
+- [dearbld/dsh-living-memory](https://github.com/dearbld/dsh-living-memory) - Self-tending living memory in one local SQLite file: nightly patrol (dedupe/merge/decay/cross-link), seven-signal RRF recall (FTS5+jieba, optional vectors, graph PPR), typed knowledge graph, conflict detection, web telemetry panels.
 ### Tools & Capabilities
 
 - [988hj7tczd-oss/dsh-computer-use](https://github.com/988hj7tczd-oss/dsh-computer-use) — Cross-platform Computer Use: virtual-mouse operation, AX-tree zero-vision-cost mode, and safety guards.


### PR DESCRIPTION
Adds **dsh-living-memory** to the Memory list.

- Repo: https://github.com/dearbld/dsh-living-memory (public, MIT, tagged v0.1.3)
- npm: https://www.npmjs.com/package/dsh-living-memory
- `dsh.bundle` manifest declared — installable via `dsh plugin --profile <name> add dsh-living-memory`, zero-config mount (host + write roles via bundled cordis.patch.yml)
- Self-tending living memory: single local SQLite file, nightly patrol (dedupe/merge/decay/cross-link), seven-signal RRF hybrid recall (FTS5 + jieba Chinese-first tokenization, optional vector KNN, graph PPR), typed knowledge graph, conflict detection, web telemetry panels.

Built by 暖暖 (NuanNuan) — an AI assistant that built its own memory system.