### PR TITLE
Add teethyachi/dsh-usage-mini to Usage & Billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Jannchie/dsh-bill](https://github.com/Jannchie/dsh-bill) — Cost tracking priced per call from models.dev + OpenRouter (8000+ models): per-turn line attributed to tool output / model output / system prompt / commands, budget, forecast.
 - [kirigayakazima/dsh-usage-vendor-stats](https://github.com/kirigayakazima/dsh-usage-vendor-stats) — Per-provider token/cache/output KPI dashboard: 53-week heatmap, hourly trend, model drilldown, CSV export, TTFT/speed/error-rate health cards.
 - [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) — Per-round cache billing in the composer context meter's popover: what the current call spends on cache hits, misses, and output in CNY, with automatic official peak/off-peak and per-model pricing; hidden on non-official DeepSeek routes.
+- [teethyachi/dsh-usage-mini](https://github.com/teethyachi/dsh-usage-mini) — Draggable floating usage window (用量小窗) that docks to a corner: Claude/Codex subscription usage windows with reset countdowns, plus today's DeepSeek API spend and cached balance; display-only, reads from dsh-plugin-subscriptions and dsh-cost-meter.
 
 ### Themes & Appearance
 


### PR DESCRIPTION
Adds one line under **Usage & Billing**, alphabetically by owner, for [teethyachi/dsh-usage-mini](https://github.com/teethyachi/dsh-usage-mini).

A draggable floating usage window for DSH Web: Claude/Codex subscription windows with reset countdowns, plus DeepSeek API spend and balance. Display-only companion to dsh-plugin-subscriptions and dsh-cost-meter; no budgets enforced and no model switching.

Current GitHub release: **v0.2.3**. Install: `dsh plugin --profile web add github:teethyachi/dsh-usage-mini#v0.2.3`. Scope remains those three services only. Real isolated DSH 0.1.2-rc.1 startup and zh/en browser checks passed, not live-account tests or universal browser certification. [Evidence](https://github.com/teethyachi/dsh-usage-mini/blob/v0.2.3/docs/store-evidence.md).

I am the author; this submission is AI-assisted. The listed one-line description is unchanged by this maintenance release.
